### PR TITLE
Fix duplicate callback and class name

### DIFF
--- a/Source/Gameplay/AttackFactories/_37AlternateJumpBackPokeChainFactory.cs
+++ b/Source/Gameplay/AttackFactories/_37AlternateJumpBackPokeChainFactory.cs
@@ -6,7 +6,7 @@ namespace PromisedEigong.Gameplay.AttackFactories;
 using static PromisedEigongModGlobalSettings.EigongAttacks;
 using static PromisedEigongModGlobalSettings.EigongSpeed;
 
-public class _37AlternateSlashUpCrimsonPokeChainFactory : BaseAttackFactory
+public class _37AlternateJumpBackPokeChainFactory : BaseAttackFactory
 {
     public override string AttackToBeCopied => JUMP_BACK;
     public override string AttackToBeCreated => ATTACK37_NEW_CHAIN_ALTERNATE_JUMP_BACK;

--- a/Source/ModSystem/EigongWrapper.cs
+++ b/Source/ModSystem/EigongWrapper.cs
@@ -198,7 +198,7 @@ public class EigongWrapper : MonoBehaviour, ICoroutineRunner
             new _34TeleportToTopSafeguardPhase3Factory(),
             new _35JumpBackSafeguardPhase3Factory(),
             new _36AlternateSlashUpCrimsonPokeChainFactory(),
-            new _37AlternateSlashUpCrimsonPokeChainFactory(),
+            new _37AlternateJumpBackPokeChainFactory(),
             new _38SpecialDoubleAttackFactory(),
             new _39SpecialDAJumpBackPhase3Factory(),
             new _40TeleportToBackComboPhase3Changer()

--- a/Source/PoolObjectWrapper/PoolObjectPatches.cs
+++ b/Source/PoolObjectWrapper/PoolObjectPatches.cs
@@ -54,7 +54,6 @@ public class PoolObjectPatches
         InvokeCallbackForComponents(__instance, PO_VFX_EIGONG_JUDGMENT_CUT, OnFoundJudgmentCutEigongBody, EIGONG_CHARACTER_BODY_NAME);
         InvokeCallbackForComponents(__instance, PO_VFX_EIGONG_JUDGMENT_CUT, OnFoundJudgmentCutEigongHair, EIGONG_CHARACTER_HAIR_SPRITE_NAME);
         InvokeCallbackForComponents(__instance, PO_VFX_EIGONG_JUDGMENT_CUT, OnFoundJudgmentCutEigongTianhuoHair, EIGONG_CHARACTER_TIANHUO_HAIR_SPRITE_NAME);
-        InvokeCallbackForComponents(__instance, PO_VFX_EIGONG_JUDGMENT_CUT, OnFoundJudgmentCutEigongTianhuoHair, EIGONG_CHARACTER_TIANHUO_HAIR_SPRITE_NAME);
         InvokeCallbackForComponents(__instance, PO_VFX_EIGONG_JUDGMENT_CUT, OnFoundJudgmentCutEigongSword, EIGONG_CHARACTER_SWORD_SPRITE_NAME);
         InvokeCallbackForComponents(__instance, PO_VFX_EIGONG_JUDGMENT_CUT_PART_2, OnFoundJudgmentCutEigongBody, EIGONG_CHARACTER_BODY_NAME);
         InvokeCallbackForComponents(__instance, PO_VFX_EIGONG_JUDGMENT_CUT_PART_2, OnFoundJudgmentCutEigongHair, EIGONG_CHARACTER_HAIR_SPRITE_NAME);


### PR DESCRIPTION
## Summary
- fix duplicate callback invocation for Tianhuo hair objects
- rename `_37AlternateSlashUpCrimsonPokeChainFactory` to `_37AlternateJumpBackPokeChainFactory`
- update factory list to use the new class name

------
https://chatgpt.com/codex/tasks/task_e_68437735fda4832ebb7aa45917adae6d